### PR TITLE
Add third parameter false to addEvent

### DIFF
--- a/media.match.js
+++ b/media.match.js
@@ -271,8 +271,8 @@ window.matchMedia || (window.matchMedia = function (win) {
             _setFeature();
 
             // Set up listeners
-            addEvent(eventPrefix + 'resize', _watch);
-            addEvent(eventPrefix + 'orientationchange', _watch);
+            addEvent(eventPrefix + 'resize', _watch, false);
+            addEvent(eventPrefix + 'orientationchange', _watch, false);
         };
 
     _init();


### PR DESCRIPTION
This prevents an error from being thrown in old versions of Firefox where the third parameter for `addEventListener` is required. Fixes #24.

(I don't know which minifier you're using and with which options... so I only included the unminified version.)